### PR TITLE
Add configurable redirect paths for redirecting after form submissions

### DIFF
--- a/civicrm_newsletter.install
+++ b/civicrm_newsletter.install
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Add redirect paths to configuration.
+ */
+function civicrm_newsletter_update_8101(&$sandbox) {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('civicrm_newsletter.settings');
+  $config->set('redirect_paths', []);
+  $config->save(TRUE);
+}

--- a/config/install/civicrm_newsletter.settings.yml
+++ b/config/install/civicrm_newsletter.settings.yml
@@ -1,1 +1,2 @@
 cmrf_connector: civicrm_newsletter
+redirect_paths: []

--- a/config/schema/civicrm_newsletter.schema.yml
+++ b/config/schema/civicrm_newsletter.schema.yml
@@ -4,3 +4,15 @@ civicrm_newsletter.settings:
     cmrf_connector:
       type: string
       label: 'CiviMRF Connector'
+    redirect_paths:
+      type: mapping
+      mapping:
+        subscription_form:
+          type: string
+          label: 'Redirect path for the subscription form'
+        preferences_form:
+          type: string
+          label: 'Redirect path for the preferences form'
+        request_link_form:
+          type: string
+          label: 'Redirect path for the request-link form'

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -19,6 +19,7 @@ use Drupal;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Element\PathElement;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\cmrf_core;
@@ -90,6 +91,8 @@ class ConfigForm extends ConfigFormBase {
       '#required' => TRUE,
     ];
 
+    $settings_definition = Drupal::service('config.typed')
+      ->getDefinition(static::SETTINGS);
     $form['redirect_paths'] = [
       '#tree' => TRUE,
       '#type' => 'details',
@@ -97,29 +100,16 @@ class ConfigForm extends ConfigFormBase {
       '#description' => $this->t('You may define paths to redirect to after successful submissions of the respective forms.'),
       '#open' => !empty($config->get('redirect_paths')),
     ];
-    $form['redirect_paths']['subscription_form'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Subscription form'),
-      '#default_value' => $config->get('redirect_paths.subscription_form'),
-    ];
-    $form['redirect_paths']['preferences_form'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Preferences form'),
-      '#default_value' => $config->get('redirect_paths.preferences_form'),
-    ];
-    $form['redirect_paths']['request_link_form'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Request link form'),
-      '#default_value' => $config->get('redirect_paths.request_link_form'),
-    ];
+    foreach ($settings_definition['mapping']['redirect_paths']['mapping'] as $redirect_path => $definition) {
+      $form['redirect_paths'][$redirect_path] = [
+        '#type' => 'path',
+        '#title' => $definition['label'],
+        '#default_value' => $config->get('redirect_paths.' . $redirect_path),
+        '#convert_path' => PathElement::CONVERT_NONE,
+      ];
+    }
 
     return $form;
-  }
-
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-
-    // TODO: Validate redirect paths.
   }
 
   /**

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -197,6 +197,8 @@ class PreferencesForm extends FormBase {
   }
 
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = Drupal::config('civicrm_newsletter.settings');
+
     // Clean the submitted values from Drupal Form API stuff.
     $params = clone $form_state;
     $params->cleanValues();
@@ -227,6 +229,18 @@ class PreferencesForm extends FormBase {
       Drupal::messenger()->addStatus(
         $this->t('Your confirmation has been successfully submitted. You will receive an e-mail with a summary of your subscriptions.')
       );
+
+      // Redirect to target from configuration.
+      if (!empty($redirect_path = $config->get('redirect_paths.preferences_form'))) {
+        /* @var Url $url */
+        $url = Drupal::service('path.validator')
+          ->getUrlIfValid($redirect_path);
+        $form_state->setRedirect(
+          $url->getRouteName(),
+          $url->getRouteParameters(),
+          $url->getOptions()
+        );
+      }
     }
   }
 

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -23,6 +23,7 @@ use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -23,6 +23,7 @@ use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -144,6 +145,8 @@ class RequestLinkForm extends FormBase {
   }
 
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = Drupal::config('civicrm_newsletter.settings');
+
     // Clean the submitted values from Drupal Form API stuff.
     $params = clone $form_state;
     $params->cleanValues();
@@ -163,6 +166,18 @@ class RequestLinkForm extends FormBase {
       Drupal::messenger()->addStatus(
         $this->t('Your request has been successfully submitted. You will receive an e-mail with a link to a confirmation page.')
       );
+
+      // Redirect to target from configuration.
+      if (!empty($redirect_path = $config->get('redirect_paths.request_link_form'))) {
+        /* @var Url $url */
+        $url = Drupal::service('path.validator')
+          ->getUrlIfValid($redirect_path);
+        $form_state->setRedirect(
+          $url->getRouteName(),
+          $url->getRouteParameters(),
+          $url->getOptions()
+        );
+      }
     }
   }
 

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -23,6 +23,7 @@ use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -149,6 +150,8 @@ class SubscriptionForm extends FormBase {
   }
 
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = Drupal::config('civicrm_newsletter.settings');
+
     // Clean the submitted values from Drupal Form API stuff.
     $params = clone $form_state;
     $params->cleanValues();
@@ -178,6 +181,17 @@ class SubscriptionForm extends FormBase {
       Drupal::messenger()->addStatus(
         $this->t('Your subscription has been successfully submitted. You will receive an e-mail with a link to a confirmation page. Your subscription will not be active until you confirm it.')
       );
+      // Redirect to target from configuration.
+      if (!empty($redirect_path = $config->get('redirect_paths.subscription_form'))) {
+        /* @var Url $url */
+        $url = Drupal::service('path.validator')
+          ->getUrlIfValid($redirect_path);
+        $form_state->setRedirect(
+          $url->getRouteName(),
+          $url->getRouteParameters(),
+          $url->getOptions()
+        );
+      }
     }
   }
 

--- a/translations/civicrm_newsletter.pot
+++ b/translations/civicrm_newsletter.pot
@@ -20,7 +20,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: CiviCRM Advanced Newsletter Management VERSION\n"
-"POT-Creation-Date: 2021-07-07 11:30+0200\n"
+"POT-Creation-Date: 2021-07-07 12:45+0200\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -73,8 +73,20 @@ msgstr ""
 msgid "Allow users to access the request link form for any profile."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0 modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:79
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0 modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:81
 msgid "CiviMRF Connector"
+msgstr ""
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the subscription form"
+msgstr ""
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the preferences form"
+msgstr ""
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the request-link form"
 msgstr ""
 
 #: modules/custom/civicrm_newsletter/js/civicrm_newsletter.js:0;0
@@ -113,51 +125,59 @@ msgstr ""
 msgid "Allow users to access the request link form for profile %profile_name."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:80
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:82
 msgid "The CiviMRF connector to use for connecting to CiviCRM. @cmrf_connectors_link"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:83
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:85
 msgid "Configure CiviMRF Connectors"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:88 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:82
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:99
+msgid "Redirect paths"
+msgstr ""
+
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:100
+msgid "You may define paths to redirect to after successful submissions of the respective forms."
+msgstr ""
+
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:89 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:83
 msgid "Could not retrieve the newsletter subscription status. Please request a new confirmation link."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:105;222
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:106;225
 msgid "Your confirmation could not be submitted, please try again later."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:111;228
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:112;231
 msgid "Your confirmation has been successfully submitted. You will receive an e-mail with a summary of your subscriptions."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:139 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:130 modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:93
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:140 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:131 modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:94
 msgid "- None -"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:192 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:139 modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:124
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:193 modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:140 modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:125
 msgid "Submit"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:100;158
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:101;161
 msgid "Your request could not be submitted, please try again later."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:106;164
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:107;167
 msgid "Your request has been successfully submitted. You will receive an e-mail with a link to a confirmation page."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:146
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:147
 msgid "Please select at least one mailing list to subscribe to."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:173
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:176
 msgid "Your subscription could not be submitted, please try again later."
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:179
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:182
 msgid "Your subscription has been successfully submitted. You will receive an e-mail with a link to a confirmation page. Your subscription will not be active until you confirm it."
 msgstr ""
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -19,16 +19,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: CiviCRM Advanced Newsletter Management VERSION\n"
-"POT-Creation-Date: 2021-07-07 11:31+0200\n"
-"PO-Revision-Date: 2021-07-07 12:23+0200\n"
+"POT-Creation-Date: 2021-07-07 12:46+0200\n"
+"PO-Revision-Date: 2021-07-07 12:48+0200\n"
+"Last-Translator: \n"
 "Language-Team: EMAIL@ADDRESS\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
-"Language: de_DE\n"
 
 #: modules/custom/civicrm_newsletter/civicrm_newsletter.info.yml:0
 #: modules/custom/civicrm_newsletter/civicrm_newsletter.links.menu.yml:0
@@ -91,9 +91,21 @@ msgstr ""
 "Profile zuzugreifen."
 
 #: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
-#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:79
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:81
 msgid "CiviMRF Connector"
 msgstr "CiviMRF-Konnektor"
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the subscription form"
+msgstr "Umleitungs-Pfad für das Abonnement-Formular"
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the preferences form"
+msgstr "Umleitungs-Pfad für das Einstellungs-Formular"
+
+#: modules/custom/civicrm_newsletter/config/schema/civicrm_newsletter.schema.yml:0
+msgid "Redirect path for the request-link form"
+msgstr "Umleitungs-Pfad für das Link-Anforderungs-Formular"
 
 #: modules/custom/civicrm_newsletter/js/civicrm_newsletter.js:0;0
 msgid "Deselect all"
@@ -143,19 +155,31 @@ msgstr ""
 "Benutzern erlauben, auf das Newsletter-Link-Anforderungs-Formular für Profil "
 "%profile_name zuzugreifen."
 
-#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:80
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:82
 msgid ""
 "The CiviMRF connector to use for connecting to CiviCRM. @cmrf_connectors_link"
 msgstr ""
 "Der CiviMRF-Konnektor, der für die Verbindung zu CiviCRM verwendet werden "
 "soll. @cmrf_connectors_link"
 
-#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:83
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:85
 msgid "Configure CiviMRF Connectors"
 msgstr "CiviMRF-Konnektoren konfigurieren"
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:88
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:82
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:99
+msgid "Redirect paths"
+msgstr "Umleitungspfade"
+
+#: modules/custom/civicrm_newsletter/src/Form/ConfigForm.php:100
+msgid ""
+"You may define paths to redirect to after successful submissions of the "
+"respective forms."
+msgstr ""
+"Sie können Pfade definieren, zu denen nach erfolgreichen Einsendungen der "
+"einzelnen Formulare umgeleitet werden soll."
+
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:89
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:83
 msgid ""
 "Could not retrieve the newsletter subscription status. Please request a new "
 "confirmation link."
@@ -163,13 +187,13 @@ msgstr ""
 "Newsletter-Abonnement-Status konnte nicht abgerufen werden. Bitte fordern "
 "Sie einen neuen Bestätigungs-Link an."
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:105;222
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:106;225
 msgid "Your confirmation could not be submitted, please try again later."
 msgstr ""
 "Die Bestätigung konnte nicht übertragen werden, bitte später erneut "
 "versuchen."
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:111;228
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:112;231
 msgid ""
 "Your confirmation has been successfully submitted. You will receive an e-"
 "mail with a summary of your subscriptions."
@@ -177,25 +201,25 @@ msgstr ""
 "Ihre Bestätigung wurde erfolgreich übermittelt. Sie erhalten eine E-Mail mit "
 "einer Zusammenfassung Ihrer Abonnements."
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:139
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:130
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:93
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:140
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:131
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:94
 msgid "- None -"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:192
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:139
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:124
+#: modules/custom/civicrm_newsletter/src/Form/PreferencesForm.php:193
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:140
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:125
 msgid "Submit"
 msgstr ""
 
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:100;158
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:101;161
 msgid "Your request could not be submitted, please try again later."
 msgstr ""
 "Ihre Anfrage konnte nicht übermittelt werden, bitte versuchen Sie es später "
 "erneut."
 
-#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:106;164
+#: modules/custom/civicrm_newsletter/src/Form/RequestLinkForm.php:107;167
 msgid ""
 "Your request has been successfully submitted. You will receive an e-mail "
 "with a link to a confirmation page."
@@ -203,18 +227,18 @@ msgstr ""
 "Ihre Anfrage wurder erfolgreich übermittelt. Sie erhalten eine E-Mail mit "
 "einem Link zu einer Bestätigungsseite."
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:146
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:147
 msgid "Please select at least one mailing list to subscribe to."
 msgstr ""
 "Bitte mindestens einen Newsletter auswählen, den Sie abonnieren möchten."
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:173
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:176
 msgid "Your subscription could not be submitted, please try again later."
 msgstr ""
 "Ihr Abonnement konnte nicht übermittelt werden, bitte versuchen Sie es "
 "später erneut."
 
-#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:179
+#: modules/custom/civicrm_newsletter/src/Form/SubscriptionForm.php:182
 msgid ""
 "Your subscription has been successfully submitted. You will receive an e-"
 "mail with a link to a confirmation page. Your subscription will not be "


### PR DESCRIPTION
This provides configurable redirect paths for redirecting after successful submissions of the subscription, preferences, and request link forms.

The configuration form validates them with the [`Path`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Render%21Element%21PathElement.php/class/PathElement/8.9.x) form element type's default validation.

Without an entered redirect path, no redirection will be done (current behavior), so this is backwards-compatible.