### PR TITLE
Support honeypot module in publicly accessible forms

### DIFF
--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -26,6 +26,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 # For Admin:
 # use Drupal\Core\Form\ConfigFormBase;
@@ -139,6 +140,19 @@ class RequestLinkForm extends FormBase {
         '#type' => 'submit',
         '#value' => t('Submit'),
       );
+    }
+
+    // Support Honeypot module, see
+    // https://www.drupal.org/project/honeypot.
+    try {
+      Drupal::service('honeypot')
+        ->addFormProtection($form, $form_state, [
+          'honeypot',
+          'time_restriction',
+        ]);
+    }
+    catch (ServiceNotFoundException $exception) {
+      // Nothing to do if the service does not exist.
     }
 
     return $form;

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -26,6 +26,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 
 class SubscriptionForm extends FormBase {
@@ -124,6 +125,19 @@ class SubscriptionForm extends FormBase {
       '#type' => 'submit',
       '#value' => $profile->submit_label ?: t('Submit'),
     );
+
+    // Support Honeypot module, see
+    // https://www.drupal.org/project/honeypot.
+    try {
+      Drupal::service('honeypot')
+        ->addFormProtection($form, $form_state, [
+          'honeypot',
+          'time_restriction',
+        ]);
+    }
+    catch (ServiceNotFoundException $exception) {
+      // Nothing to do if the service does not exist.
+    }
 
     return $form;
   }


### PR DESCRIPTION
This adds support for the [Honeypot](https://www.drupal.org/project/honeypot) module in publicly accessible forms:

* Subscription form
* Request link form

by using its service:

```php
 \Drupal::service('honeypot')->addFormProtection($form, $form_state, ['honeypot', 'time_restriction']);
```

with both methods (`honeypot` and `time_restrictor`) enabled.