### PR TITLE
Correctly handle unchecked checkboxes/radios by filtering according to allowed options

### DIFF
--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -137,7 +137,7 @@ class PreferencesForm extends FormBase {
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if ($contact_field['active']) {
         $form[$contact_field_name] = [
-          '#type' => Utils::contactFieldTypes()[$contact_field['type']],
+          '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
           '#default_value' => $subscription['contact'][$contact_field_name],
@@ -158,6 +158,7 @@ class PreferencesForm extends FormBase {
       $profile->mailing_lists_tree,
       $subscription['subscription_status']
     );
+    $form['mailing_lists']['#type'] = 'fieldset';
     $form['mailing_lists']['#title'] = $profile->mailing_lists_label;
     $form['mailing_lists']['#description'] = $profile->mailing_lists_description;
     $form['mailing_lists']['#attributes'] = [
@@ -220,6 +221,14 @@ class PreferencesForm extends FormBase {
       if (strpos($name, 'mailing_lists_') === 0) {
         $params['mailing_lists'][explode('mailing_lists_', $name)[1]] = $value;
         unset($params[$name]);
+      }
+      elseif (is_array($value)) {
+        // For fields with multiple values, drop those that are unchecked, i.e.
+        // those that don't match their key (as unchecked checkboxes have a
+        // value of 0, and checked ones their respective key.
+        $params[$name] = array_filter($value, function($value, $key) {
+          return $key == $value;
+        }, ARRAY_FILTER_USE_BOTH);
       }
     }
     $params['mailing_lists'] = array_map(function($value) {

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -121,7 +121,7 @@ class RequestLinkForm extends FormBase {
       foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
         if ($contact_field['active']) {
           $form[$contact_field_name] = array(
-            '#type' => Utils::contactFieldTypes()[$contact_field['type']],
+            '#type' => Utils::getContactFieldType($contact_field),
             '#title' => $contact_field['label'],
             '#description' => $contact_field['description'],
             '#required' => !empty($contact_field['required']),
@@ -166,6 +166,17 @@ class RequestLinkForm extends FormBase {
     $params = clone $form_state;
     $params->cleanValues();
     $params = $params->getValues();
+
+    foreach ($params as $name => $value) {
+      if (is_array($value)) {
+        // For fields with multiple values, drop those that are unchecked, i.e.
+        // those that don't match their key (as unchecked checkboxes have a
+        // value of 0, and checked ones their respective key.
+        $params[$name] = array_filter($value, function($value, $key) {
+          return $key == $value;
+        }, ARRAY_FILTER_USE_BOTH);
+      }
+    }
 
     // Submit the subscription using CiviMRF.
     $result = $this->cmrf->subscriptionRequest($params);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -32,7 +32,22 @@ class Utils {
       'Text' => 'textfield',
       'Textarea' => 'textarea',
       'CheckBox' => 'checkbox',
+      'Radio' => 'radio',
     );
+  }
+
+  public static function getContactFieldType($field) {
+    $type = self::contactFieldTypes()[$field['type']];
+    if ($type == 'checkbox' && isset($field['options'])) {
+      $type = 'checkboxes';
+    }
+    if ($type == 'radio' && isset($field['options'])) {
+      $type = 'radios';
+    }
+     if ($type == 'radio' && !isset($field['options'])) {
+       $type = 'checkbox';
+     }
+    return $type;
   }
 
   /**
@@ -46,7 +61,7 @@ class Utils {
    * @return array
    */
   public static function mailingListsTreeCheckboxes($tree, $default_values = array()) {
-    $element = array();
+    $element = [];
     // Add an extra level of fieldsets for distinguishing between parent and
     // child groups.
     if (Drupal::config('civicrm_newsletter.settings')->get('parent_groups_selectable')) {


### PR DESCRIPTION
Fixes #9 by comparing Drupal's form values' keys and values (as they match when a checkbox/radio button is selected), effectively filtering out `0` values, which caused problems in the CiviCRM API when being submitted. `0` values are not allowed as options for checkboxes/radios in Drupal anyway.

This also adds support for `Radio` type CiviCRM fields also, as those suffer from the same logic and were missing definition, see systopia/de.systopia.newsletter#24.