### PR TITLE
Replace occurrences of "hash" with "checksum".

### DIFF
--- a/civicrm_newsletter.routing.yml
+++ b/civicrm_newsletter.routing.yml
@@ -19,7 +19,7 @@ civicrm_newsletter.subscription_form:
         type: civicrm_newsletter_profile
 
 civicrm_newsletter.optin:
-  path: '/civicrm_newsletter/optin/{profile}/{contact_hash}'
+  path: '/civicrm_newsletter/optin/{profile}/{contact_checksum}'
   defaults:
     _title_callback: '\Drupal\civicrm_newsletter\Controller\OptIn::title'
     _controller: '\Drupal\civicrm_newsletter\Controller\OptIn::buildPage'
@@ -29,12 +29,12 @@ civicrm_newsletter.optin:
     parameters:
       profile:
         type: civicrm_newsletter_profile
-      contact_hash:
+      contact_checksum:
         type: string
     no_cache: TRUE
 
 civicrm_newsletter.preferences_form:
-  path: '/civicrm_newsletter/preferences/{profile}/{contact_hash}'
+  path: '/civicrm_newsletter/preferences/{profile}/{contact_checksum}'
   defaults:
     _title_callback: '\Drupal\civicrm_newsletter\Form\PreferencesForm::title'
     _form: '\Drupal\civicrm_newsletter\Form\PreferencesForm'
@@ -44,21 +44,21 @@ civicrm_newsletter.preferences_form:
     parameters:
       profile:
         type: civicrm_newsletter_profile
-      contact_hash:
+      contact_checksum:
         type: string
     no_cache: TRUE
 
 civicrm_newsletter.request_link_form:
-  path: '/civicrm_newsletter/request_link/{profile}/{contact_hash}'
+  path: '/civicrm_newsletter/request_link/{profile}/{contact_checksum}'
   defaults:
     _title_callback: '\Drupal\civicrm_newsletter\Form\RequestLinkForm::title'
     _form: '\Drupal\civicrm_newsletter\Form\RequestLinkForm'
-    contact_hash: null
+    contact_checksum: null
   requirements:
     _custom_access: '\Drupal\civicrm_newsletter\Form\RequestLinkForm::access'
   options:
     parameters:
       profile:
         type: civicrm_newsletter_profile
-      contact_hash:
+      contact_checksum:
         type: string

--- a/src/CiviMRF.php
+++ b/src/CiviMRF.php
@@ -140,27 +140,27 @@ class CiviMRF {
   }
 
   /**
-   * Retrieves the subscription status for a given contact hash.
+   * Retrieves the subscription status for a given contact checksum.
    *
    * @param string | NULL $profile_name
    *   The name of the Advanced Newsletter Management profile to retrieve, or NULL
    *   to retrieve all configured Advanced Newsletter Management profiles.
    *
-   * @param string $contact_hash
+   * @param string $contact_checksum
    *
    * @return array | NULL
    *   The subscription status for the mailing lists defined within the Advanced
    *   Newsletter Management profile, or NULL if the subscription status could not
    *   be retrieved.
    */
-  public function subscriptionGet($profile_name, $contact_hash) {
+  public function subscriptionGet($profile_name, $contact_checksum) {
     $call = $call = $this->core->createCall(
       $this->connector(),
       'NewsletterSubscription',
       'get',
       [
         'profile' => $profile_name,
-        'contact_hash' => $contact_hash
+        'contact_checksum' => $contact_checksum
       ],
       []
     );

--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -96,16 +96,16 @@ class OptIn extends ControllerBase {
    *
    * @param stdClass $profile
    *   The Advanced Newsletter Management profile.
-   * @param null $contact_hash
-   *   The CiviCRM Contact hash identifying the newsletter subscriber.
+   * @param null $contact_checksum
+   *   The CiviCRM Contact checksum identifying the newsletter subscriber.
    */
-  public function buildPage(stdClass $profile = NULL, $contact_hash = NULL) {
+  public function buildPage(stdClass $profile = NULL, $contact_checksum = NULL) {
     $config = Drupal::config('civicrm_newsletter.settings');
     $page = [];
     $messages = [];
 
     // Retrieve subscription status for contact.
-    if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_hash)) {
+    if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_checksum)) {
       Drupal::messenger()->addWarning(
         $this->t('Could not retrieve the newsletter subscription status. Please request a new confirmation link.')
       );
@@ -118,7 +118,7 @@ class OptIn extends ControllerBase {
       // Automatically confirm pending subscriptions.
       $result = $this->cmrf->subscriptionAutoconfirm([
         'contact_id' => $subscription['contact']['id'],
-        'contact_hash' => $subscription['contact']['hash'],
+        'contact_checksum' => $subscription['contact']['checksum'],
         'profile' => $profile->name,
       ]);
       if (!empty($result['is_error'])) {

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -75,7 +75,7 @@ class PreferencesForm extends FormBase {
     array $form,
     FormStateInterface $form_state,
     stdClass $profile = NULL,
-    $contact_hash = NULL
+    $contact_checksum = NULL
   ) {
     $config = Drupal::config('civicrm_newsletter.settings');
 
@@ -86,7 +86,7 @@ class PreferencesForm extends FormBase {
     );
 
     // Retrieve subscription status for contact.
-    if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_hash)) {
+    if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_checksum)) {
       Drupal::messenger()->addWarning(
         $this->t('Could not retrieve the newsletter subscription status. Please request a new confirmation link.')
       );
@@ -100,7 +100,7 @@ class PreferencesForm extends FormBase {
         // Automatically confirm pending subscriptions.
         $result = $this->cmrf->subscriptionAutoconfirm([
           'contact_id' => $subscription['contact']['id'],
-          'contact_hash' => $subscription['contact']['hash'],
+          'contact_checksum' => $subscription['contact']['checksum'],
           'profile' => $profile->name,
         ]);
         if (!empty($result['is_error'])) {
@@ -123,9 +123,9 @@ class PreferencesForm extends FormBase {
       }
     }
 
-    $form['contact_hash'] = [
+    $form['contact_checksum'] = [
       '#type' => 'value',
-      '#value' => $subscription['contact']['hash'],
+      '#value' => $subscription['contact']['checksum'],
     ];
     $form['contact_id'] = [
       '#type' => 'value',

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -75,11 +75,11 @@ class RequestLinkForm extends FormBase {
     array $form,
     FormStateInterface $form_state,
     stdClass $profile = NULL,
-    $contact_hash = NULL
+    $contact_checksum = NULL
   ) {
-    // If a hash is given, submit to the request API action without showing a form.
-    if ($contact_hash) {
-      if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_hash)) {
+    // If a checksum is given, submit to the request API action without showing a form.
+    if ($contact_checksum) {
+      if (!$subscription = $this->cmrf->subscriptionGet($profile->name, $contact_checksum)) {
         Drupal::messenger()->addWarning(
           $this->t('Could not retrieve the newsletter subscription status. Please request a new confirmation link.')
         );
@@ -91,7 +91,7 @@ class RequestLinkForm extends FormBase {
 
       $params = array(
         'profile' => $profile->name,
-        'contact_hash' => $subscription['contact']['hash'],
+        'contact_checksum' => $subscription['contact']['checksum'],
         'contact_id' => $subscription['contact']['id'],
       );
       $result = $this->cmrf->subscriptionRequest($params);


### PR DESCRIPTION
Fixes #7.

This replaces all occurrences of the deprecated use of contact hashes, as systopia/de.systopia.newsletter#21 implemented (but left a backwards-compatibility layer by processing contact checksums with the same parameter names that were previously used for contact hashes).

This requires `de.systopia.newsletter` in at least version `1.0-beta1`.