### PR TITLE
Throw exception when retrieving profile fails

### DIFF
--- a/src/Routing/ProfileConverter.php
+++ b/src/Routing/ProfileConverter.php
@@ -46,7 +46,11 @@ class ProfileConverter implements ParamConverterInterface {
    */
   public function convert($value, $definition, $name, array $defaults) {
     try {
-      return (object) $this->cmrf->profileGetSingle($value);
+      $profile = $this->cmrf->profileGetSingle($value);
+      if (empty($profile)) {
+        throw new NotFoundHttpException();
+      }
+      return (object) $profile;
     } catch (Exception $exception) {
       throw new NotFoundHttpException();
     }


### PR DESCRIPTION
Fixes #15.

Throw an exception when retrieving the profile fails (the profile could not be found) in the route parameter converter.