### PR TITLE
Prepopulate contact fields with default values from the request

### DIFF
--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -90,6 +90,7 @@ class SubscriptionForm extends FormBase {
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
           '#required' => !empty($contact_field['required']),
+          '#default_value' => $this->getRequest()->get($contact_field_name),
         );
         if (!empty($contact_field['options'])) {
           $form[$contact_field_name]['#options'] = $contact_field['options'];


### PR DESCRIPTION
This allows for redirects, e.g. from separate sites that want to use the module's forms on a different domain, but provide a simple "enter e-mail address for newsletter" form with a redirect to the actual forms, but without requiring the user to enter their e-mail address twice.

Maybe some validation should be added, but I guess the Drupal Form API will already filter `#default_value`s.