### PR TITLE
Fix external redirects

### DIFF
--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -20,6 +20,7 @@ use Drupal\civicrm_newsletter\CiviMRF;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
@@ -144,15 +145,11 @@ class OptIn extends ControllerBase {
     // Redirect to target from configuration.
     if (!empty($redirect_path = $config->get('redirect_paths.optin_page'))) {
       /* @var Url $url */
-      $url = Drupal::service('path.validator')
-        ->getUrlIfValid($redirect_path);
-      $page = $this->redirect(
-        $url->getRouteName(),
-        $url->getRouteParameters(),
-        $url->getOptions()
-      );
+      $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
+      $page = new TrustedRedirectResponse($url->getUri());
     }
-    if (!is_a($page, RedirectResponse::class) || !$config->get('redirect_disable_messages')) {
+
+    if (!$page instanceof RedirectResponse || !$config->get('redirect_disable_messages')) {
       foreach ($messages as $message) {
         switch ($message['status']) {
           case Drupal::messenger()::TYPE_STATUS:

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -22,11 +22,12 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class PreferencesForm extends FormBase {
 
@@ -292,25 +293,28 @@ class PreferencesForm extends FormBase {
       && !empty($redirect_path = $config->get('redirect_paths.unsubscribe'))
     ) {
       /* @var Url $url */
-      $url = Drupal::service('path.validator')
-        ->getUrlIfValid($redirect_path);
-      $form_state->setRedirect(
-        $url->getRouteName(),
-        $url->getRouteParameters(),
-        $url->getOptions()
-      );
+      $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
+      if ($url->isRouted()) {
+        $form_state->setRedirectUrl($url);
+      }
+      else {
+        $form_state->setResponse(new TrustedRedirectResponse($url->getUri()));
+      }
     }
     elseif (!empty($redirect_path = $config->get('redirect_paths.preferences_form'))) {
       /* @var Url $url */
-      $url = Drupal::service('path.validator')
-        ->getUrlIfValid($redirect_path);
-      $form_state->setRedirect(
-        $url->getRouteName(),
-        $url->getRouteParameters(),
-        $url->getOptions()
-      );
+      $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
+      if ($url->isRouted()) {
+        $form_state->setRedirectUrl($url);
+      }
+      else {
+        $form_state->setResponse(new TrustedRedirectResponse($url->getUri()));
+      }
     }
-    if (!$form_state->getRedirect() || !$config->get('redirect_disable_messages')) {
+
+    if ((!$form_state->getRedirect() && !$form_state->getResponse() instanceof RedirectResponse)
+      || !$config->get('redirect_disable_messages')
+    ) {
       foreach ($messages as $message) {
         switch ($message['status']) {
           case Drupal::messenger()::TYPE_STATUS:

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -22,11 +22,13 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 # For Admin:
 # use Drupal\Core\Form\ConfigFormBase;
@@ -197,11 +199,18 @@ class RequestLinkForm extends FormBase {
       // Redirect to target from configuration.
       if (!empty($redirect_path = $config->get('redirect_paths.request_link_form'))) {
         /* @var Url $url */
-        $url = Drupal::service('path.validator')
-          ->getUrlIfValid($redirect_path);
-        $form_state->setRedirectUrl($url);
+        $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
+        if ($url->isRouted()) {
+          $form_state->setRedirectUrl($url);
+        }
+        else {
+          $form_state->setResponse(new TrustedRedirectResponse($url->getUri()));
+        }
       }
-      if (!$form_state->getRedirect() || !$config->get('redirect_disable_messages')) {
+
+      if ((!$form_state->getRedirect() && !$form_state->getResponse() instanceof RedirectResponse)
+        || !$config->get('redirect_disable_messages')
+      ) {
         foreach ($messages as $message) {
           switch ($message['status']) {
             case Drupal::messenger()::TYPE_STATUS:

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -22,11 +22,13 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultReasonInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use stdClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class SubscriptionForm extends FormBase {
 
@@ -221,11 +223,18 @@ class SubscriptionForm extends FormBase {
       // Redirect to target from configuration.
       if (!empty($redirect_path = $config->get('redirect_paths.subscription_form'))) {
         /* @var Url $url */
-        $url = Drupal::service('path.validator')
-          ->getUrlIfValid($redirect_path);
-        $form_state->setRedirectUrl($url);
+        $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
+        if ($url->isRouted()) {
+          $form_state->setRedirectUrl($url);
+        }
+        else {
+          $form_state->setResponse(new TrustedRedirectResponse($url->getUri()));
+        }
       }
-      if (!$form_state->getRedirect() || !$config->get('redirect_disable_messages')) {
+
+      if ((!$form_state->getRedirect() && !$form_state->getResponse() instanceof RedirectResponse)
+        || !$config->get('redirect_disable_messages')
+      ) {
         foreach ($messages as $message) {
           switch ($message['status']) {
             case Drupal::messenger()::TYPE_STATUS:


### PR DESCRIPTION
Depending on the Drupal configuration redirects to external URLs previously might fail with this message:
Redirects to external URLs are not allowed by default, use \Drupal\Core\Routing\TrustedRedirectResponse for it.

systopia-reference: 24542