### PR TITLE
added weight attribute to form fields

### DIFF
--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -145,7 +145,7 @@ class PreferencesForm extends FormBase {
           '#required' => !empty($contact_field['required']),
           '#disabled' => TRUE,
           '#weight' => isset($contact_field['weight'])
-                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== FALSE
                     ? $contact_field['weight'] : 0,
         ];
         if (!empty($contact_field['options'])) {

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -137,7 +137,7 @@ class PreferencesForm extends FormBase {
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if (isset($contact_field['active']) && $contact_field['active']) {
-        $form['contact-fields'][$contact_field_name] = [
+        $form['contact_fields'][$contact_field_name] = [
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
@@ -149,9 +149,9 @@ class PreferencesForm extends FormBase {
                     ? $contact_field['weight'] : 0,
         ];
         if (!empty($contact_field['options'])) {
-          $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
+          $form['contact_fields'][$contact_field_name]['#options'] = $contact_field['options'];
           if (empty($contact_field['required'])) {
-            $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
+            $form['contact_fields'][$contact_field_name]['#empty_option'] = t('- None -');
           }
         }
       }

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -137,13 +137,14 @@ class PreferencesForm extends FormBase {
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if ($contact_field['active']) {
-        $form[$contact_field_name] = [
+        $form['contact-fields'][$contact_field_name] = [
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
           '#default_value' => $subscription['contact'][$contact_field_name],
           '#required' => !empty($contact_field['required']),
           '#disabled' => TRUE,
+          '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
         ];
         if (!empty($contact_field['options'])) {
           $form[$contact_field_name]['#options'] = $contact_field['options'];

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -136,7 +136,7 @@ class PreferencesForm extends FormBase {
     // Build form according to retrieved configuration:
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
-      if ($contact_field['active']) {
+      if (isset($contact_field['active']) && $contact_field['active']) {
         $form['contact-fields'][$contact_field_name] = [
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
@@ -144,12 +144,14 @@ class PreferencesForm extends FormBase {
           '#default_value' => $subscription['contact'][$contact_field_name],
           '#required' => !empty($contact_field['required']),
           '#disabled' => TRUE,
-          '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
+          '#weight' => isset($contact_field['weight'])
+                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                    ? $contact_field['weight'] : 0,
         ];
         if (!empty($contact_field['options'])) {
-          $form[$contact_field_name]['#options'] = $contact_field['options'];
+          $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
           if (empty($contact_field['required'])) {
-            $form[$contact_field_name]['#empty_option'] = t('- None -');
+            $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
           }
         }
       }

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -128,7 +128,7 @@ class RequestLinkForm extends FormBase {
             '#description' => $contact_field['description'],
             '#required' => !empty($contact_field['required']),
             '#weight' => isset($contact_field['weight'])
-                      && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                      && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== FALSE
                       ? $contact_field['weight'] : 0,
           );
           if (!empty($contact_field['options'])) {

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -122,11 +122,12 @@ class RequestLinkForm extends FormBase {
       // Add contact fields.
       foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
         if ($contact_field['active']) {
-          $form[$contact_field_name] = array(
+          $form['contact-fields'][$contact_field_name] = array(
             '#type' => Utils::getContactFieldType($contact_field),
             '#title' => $contact_field['label'],
             '#description' => $contact_field['description'],
             '#required' => !empty($contact_field['required']),
+            '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
           );
           if (!empty($contact_field['options'])) {
             $form[$contact_field_name]['#options'] = $contact_field['options'];

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -121,18 +121,20 @@ class RequestLinkForm extends FormBase {
       // Build form according to received configuration:
       // Add contact fields.
       foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
-        if ($contact_field['active']) {
+        if (isset($contact_field['active']) && $contact_field['active']) {
           $form['contact-fields'][$contact_field_name] = array(
             '#type' => Utils::getContactFieldType($contact_field),
             '#title' => $contact_field['label'],
             '#description' => $contact_field['description'],
             '#required' => !empty($contact_field['required']),
-            '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
+            '#weight' => isset($contact_field['weight'])
+                      && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                      ? $contact_field['weight'] : 0,
           );
           if (!empty($contact_field['options'])) {
-            $form[$contact_field_name]['#options'] = $contact_field['options'];
+            $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
             if (empty($contact_field['required'])) {
-              $form[$contact_field_name]['#empty_option'] = t('- None -');
+              $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
             }
           }
         }

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -122,7 +122,7 @@ class RequestLinkForm extends FormBase {
       // Add contact fields.
       foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
         if (isset($contact_field['active']) && $contact_field['active']) {
-          $form['contact-fields'][$contact_field_name] = array(
+          $form['contact_fields'][$contact_field_name] = array(
             '#type' => Utils::getContactFieldType($contact_field),
             '#title' => $contact_field['label'],
             '#description' => $contact_field['description'],
@@ -132,9 +132,9 @@ class RequestLinkForm extends FormBase {
                       ? $contact_field['weight'] : 0,
           );
           if (!empty($contact_field['options'])) {
-            $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
+            $form['contact_fields'][$contact_field_name]['#options'] = $contact_field['options'];
             if (empty($contact_field['required'])) {
-              $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
+              $form['contact_fields'][$contact_field_name]['#empty_option'] = t('- None -');
             }
           }
         }

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -92,7 +92,7 @@ class SubscriptionForm extends FormBase {
           '#description' => $contact_field['description'],
           '#required' => !empty($contact_field['required']),
           '#weight' => isset($contact_field['weight'])
-                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== FALSE
                     ? $contact_field['weight'] : 0,
         );
         if (!empty($contact_field['options'])) {

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -91,12 +91,14 @@ class SubscriptionForm extends FormBase {
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
           '#required' => !empty($contact_field['required']),
-          '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
+          '#weight' => isset($contact_field['weight'])
+                    && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false
+                    ? $contact_field['weight'] : 0,
         );
         if (!empty($contact_field['options'])) {
-          $form[$contact_field_name]['#options'] = $contact_field['options'];
+          $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
           if (empty($contact_field['required'])) {
-            $form[$contact_field_name]['#empty_option'] = t('- None -');
+            $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
           }
         }
       }

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -86,11 +86,12 @@ class SubscriptionForm extends FormBase {
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if ($contact_field['active']) {
-        $form[$contact_field_name] = array(
+        $form['contact-fields'][$contact_field_name] = array(
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
           '#required' => !empty($contact_field['required']),
+          '#weight' => filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== false ? $contact_field['weight'] : 0,
         );
         if (!empty($contact_field['options'])) {
           $form[$contact_field_name]['#options'] = $contact_field['options'];

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -86,7 +86,7 @@ class SubscriptionForm extends FormBase {
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if (isset($contact_field['active']) && $contact_field['active']) {
-        $form['contact-fields'][$contact_field_name] = array(
+        $form['contact_fields'][$contact_field_name] = array(
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],
           '#description' => $contact_field['description'],
@@ -96,9 +96,9 @@ class SubscriptionForm extends FormBase {
                     ? $contact_field['weight'] : 0,
         );
         if (!empty($contact_field['options'])) {
-          $form['contact-fields'][$contact_field_name]['#options'] = $contact_field['options'];
+          $form['contact_fields'][$contact_field_name]['#options'] = $contact_field['options'];
           if (empty($contact_field['required'])) {
-            $form['contact-fields'][$contact_field_name]['#empty_option'] = t('- None -');
+            $form['contact_fields'][$contact_field_name]['#empty_option'] = t('- None -');
           }
         }
       }

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -85,7 +85,7 @@ class SubscriptionForm extends FormBase {
     // Build form according to received configuration:
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
-      if ($contact_field['active']) {
+      if (isset($contact_field['active']) && $contact_field['active']) {
         $form['contact-fields'][$contact_field_name] = array(
           '#type' => Utils::getContactFieldType($contact_field),
           '#title' => $contact_field['label'],

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -29,6 +29,7 @@ class Utils {
     return array(
       'Select' => 'select',
       'Multi-Select' => 'checkboxes',
+      'Number' => 'textfield',
       'Text' => 'textfield',
       'Textarea' => 'textarea',
       'CheckBox' => 'checkbox',

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -29,7 +29,6 @@ class Utils {
     return array(
       'Select' => 'select',
       'Multi-Select' => 'checkboxes',
-      'Number' => 'textfield',
       'Text' => 'textfield',
       'Textarea' => 'textarea',
       'CheckBox' => 'checkbox',


### PR DESCRIPTION
enabled weight attributes in contact-fields.

grouped contact-fields into separate 'contact-fields' element in $form map, in order to prevent side-effects on other form-elements that are not related to contact-fields and that do not use a weight.

a unset weight attribute of a contact-field is set to 0 by default, in order to properly sort the field if other fields have weight values that have been set to 0 explicitly.

*systopia-reference: 24994*