### PR TITLE
Prepopulate contact fields with default values from the request

### DIFF
--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -117,6 +117,7 @@ class SubscriptionForm extends FormBase {
           '#weight' => isset($contact_field['weight'])
                     && filter_var($contact_field['weight'], FILTER_VALIDATE_INT) !== FALSE
                     ? $contact_field['weight'] : 0,
+          '#default_value' => $this->getRequest()->get($contact_field_name),
         );
         if (!empty($contact_field['options'])) {
           $form['contact_fields'][$contact_field_name]['#options'] = $contact_field['options'];


### PR DESCRIPTION
Replaces #20 

New PR as it is against another branch (`1.0.x` instead of `1.x`)