### PR TITLE
Add form description fields

### DIFF
--- a/civicrm_newsletter.info.yml
+++ b/civicrm_newsletter.info.yml
@@ -10,4 +10,4 @@ dependencies:
 'interface translation project': civicrm_newsletter
 'interface translation server pattern': https://systopia.github.io/civicrm_newsletter/translations/%language.po
 
-version: 1.0-dev
+version: 1.1-dev

--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -146,7 +146,8 @@ class OptIn extends ControllerBase {
     if (!empty($redirect_path = $config->get('redirect_paths.optin_page'))) {
       /* @var Url $url */
       $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
-      $page = new TrustedRedirectResponse($url->getUri());
+      $url->setAbsolute(TRUE);
+      $page = new TrustedRedirectResponse($url->toString());
     }
 
     if (!$page instanceof RedirectResponse || !$config->get('redirect_disable_messages')) {

--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -147,7 +147,7 @@ class OptIn extends ControllerBase {
       /* @var Url $url */
       $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
       $url->setAbsolute(TRUE);
-      $page = new TrustedRedirectResponse($url->toString());
+      $page = new TrustedRedirectResponse($url->toString(TRUE));
     }
 
     if (!$page instanceof RedirectResponse || !$config->get('redirect_disable_messages')) {

--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -147,7 +147,7 @@ class OptIn extends ControllerBase {
       /* @var Url $url */
       $url = Drupal::service('path.validator')->getUrlIfValid($redirect_path);
       $url->setAbsolute(TRUE);
-      $page = new TrustedRedirectResponse($url->toString(TRUE));
+      $page = new TrustedRedirectResponse($url->toString(TRUE)->getGeneratedUrl());
     }
 
     if (!$page instanceof RedirectResponse || !$config->get('redirect_disable_messages')) {

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -88,24 +88,27 @@ class SubscriptionForm extends FormBase {
     // - Only use the #description attribute of fieldsets in order to show unformated,
     //   multiline text without scrollbars or color formating.
     // - #description text is automatically scalled to window width.
-    foreach ($profile->contact_form_descriptions as $contact_form_description_name => $contact_form_description_data) {
-      $is_active = isset($contact_form_description_data['active']) && $contact_form_description_data['active'];
-      $has_description = isset($contact_form_description_data['description']) && strlen($contact_form_description_data['description']) > 0;
+    if (isset($profile->contact_form_descriptions)) {
+      foreach ($profile->contact_form_descriptions as $contact_form_description_name => $contact_form_description_data) {
+        $is_active = (bool) ($contact_form_description_data['active'] ?? FALSE);
+        $has_description = '' !== ($contact_form_description_data['description'] ?? '');
+        
+        if ($is_active && $has_description) {
+          $has_weight = isset($contact_form_description_data['weight'])
+                              && filter_var($contact_form_description_data['weight'], FILTER_VALIDATE_INT) !== FALSE;
+          $weight = $has_weight ? $contact_form_description_data['weight'] : 0;
 
-      if ($is_active && $has_description) {
-        $has_weight = isset($contact_form_description_data['weight'])
-                           && filter_var($contact_form_description_data['weight'], FILTER_VALIDATE_INT) !== FALSE;
-        $weight = $has_weight ? $contact_form_description_data['weight'] : 0;
-
-        $form['contact_fields'][$contact_form_description_name] = array(
-          '#type' => 'fieldset',
-          '#disabled' => TRUE,
-          '#description' => $contact_form_description_data['description'],
-          '#weight' => $weight,
-        );
+          $form['contact_fields'][$contact_form_description_name] = array(
+            '#type' => 'markup',
+            '#disabled' => TRUE,
+            '#markup' => $contact_form_description_data['description'],
+            '#weight' => $weight,
+          );
+        }
       }
     }
-
+    
+    // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if (isset($contact_field['active']) && $contact_field['active']) {
         $form['contact_fields'][$contact_field_name] = array(

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -88,23 +88,21 @@ class SubscriptionForm extends FormBase {
     // - Only use the #description attribute of fieldsets in order to show unformated,
     //   multiline text without scrollbars or color formating.
     // - #description text is automatically scalled to window width.
-    if (isset($profile->contact_form_descriptions)) {
-      foreach ($profile->contact_form_descriptions as $contact_form_description_name => $contact_form_description_data) {
-        $is_active = (bool) ($contact_form_description_data['active'] ?? FALSE);
-        $has_description = '' !== ($contact_form_description_data['description'] ?? '');
-        
-        if ($is_active && $has_description) {
-          $has_weight = isset($contact_form_description_data['weight'])
-                              && filter_var($contact_form_description_data['weight'], FILTER_VALIDATE_INT) !== FALSE;
-          $weight = $has_weight ? $contact_form_description_data['weight'] : 0;
+    foreach ($profile->contact_form_descriptions ?? [] as $contact_form_description_name => $contact_form_description_data) {
+      if (
+        (bool) ($contact_form_description_data['active'] ?? FALSE)
+        && ('' !== ($contact_form_description_data['description'] ?? ''))
+      ) {
+        $has_weight = isset($contact_form_description_data['weight'])
+                            && filter_var($contact_form_description_data['weight'], FILTER_VALIDATE_INT) !== FALSE;
+        $weight = $has_weight ? $contact_form_description_data['weight'] : 0;
 
-          $form['contact_fields'][$contact_form_description_name] = array(
-            '#type' => 'markup',
-            '#disabled' => TRUE,
-            '#markup' => $contact_form_description_data['description'],
-            '#weight' => $weight,
-          );
-        }
+        $form['contact_fields'][$contact_form_description_name] = array(
+          '#type' => 'markup',
+          '#disabled' => TRUE,
+          '#markup' => $contact_form_description_data['description'],
+          '#weight' => $weight,
+        );
       }
     }
     

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -83,7 +83,29 @@ class SubscriptionForm extends FormBase {
     );
 
     // Build form according to received configuration:
-    // Add contact fields.
+
+    // Add form description fields as empty fieldsets.
+    // - Only use the #description attribute of fieldsets in order to show unformated,
+    //   multiline text without scrollbars or color formating.
+    // - #description text is automatically scalled to window width.
+    foreach ($profile->contact_form_descriptions as $contact_form_description_name => $contact_form_description_data) {
+      $is_active = isset($contact_form_description_data['active']) && $contact_form_description_data['active'];
+      $has_description = isset($contact_form_description_data['description']) && strlen($contact_form_description_data['description']) > 0;
+
+      if ($is_active && $has_description) {
+        $has_weight = isset($contact_form_description_data['weight'])
+                           && filter_var($contact_form_description_data['weight'], FILTER_VALIDATE_INT) !== FALSE;
+        $weight = $has_weight ? $contact_form_description_data['weight'] : 0;
+
+        $form['contact_fields'][$contact_form_description_name] = array(
+          '#type' => 'fieldset',
+          '#disabled' => TRUE,
+          '#description' => $contact_form_description_data['description'],
+          '#weight' => $weight,
+        );
+      }
+    }
+
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if (isset($contact_field['active']) && $contact_field['active']) {
         $form['contact_fields'][$contact_field_name] = array(


### PR DESCRIPTION
(reopened accidentially closed PR #26)

new feature includes a display of read-only markup fields that can be positioned within a newsletter subscribe form and may contain additional descriptive text relöated to the form.