### PR TITLE
Mark as compatible with Drupal 11

### DIFF
--- a/civicrm_newsletter.info.yml
+++ b/civicrm_newsletter.info.yml
@@ -2,7 +2,7 @@ name: CiviCRM Advanced Newsletter Management
 type: module
 description: 'In combination with the "Advanced Newsletter Management" extension, provides better Newsletter subscription and opt-in forms for CiviCRM contacts.'
 package: CiviCRM
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 configure: civicrm_newsletter.config_form
 dependencies:
   - cmrf_core

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
     ],
     "homepage": "https://github.com/systopia/civicrm_newsletter",
     "require": {
-        "drupal/cmrf_core": "^1.0@beta | ^2.0@beta | ^2.1@beta"
+        "drupal/cmrf_core": "^2.1"
     }
 }


### PR DESCRIPTION
[Upgrade Status](https://www.drupal.org/project/upgrade_status) had nothing to complain. [Drupal Rector](https://github.com/palantirnet/drupal-rector) didn't suggest any change.

Drupal 9 and drupal/cmrf_core:^1 are dropped so we don't have to care for compatibility.

systopia-reference: 31242