### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -100,7 +100,7 @@ class OptIn extends ControllerBase {
    * @param null $contact_checksum
    *   The CiviCRM Contact checksum identifying the newsletter subscriber.
    */
-  public function buildPage(stdClass $profile = NULL, $contact_checksum = NULL) {
+  public function buildPage(?stdClass $profile = NULL, $contact_checksum = NULL) {
     $config = Drupal::config('civicrm_newsletter.settings');
     $page = [];
     $messages = [];

--- a/src/Controller/OptIn.php
+++ b/src/Controller/OptIn.php
@@ -95,12 +95,12 @@ class OptIn extends ControllerBase {
   /**
    * Build the opt-in page
    *
-   * @param stdClass $profile
+   * @param stdClass|null $profile
    *   The Advanced Newsletter Management profile.
-   * @param null $contact_checksum
+   * @param string|null $contact_checksum
    *   The CiviCRM Contact checksum identifying the newsletter subscriber.
    */
-  public function buildPage(?stdClass $profile = NULL, $contact_checksum = NULL) {
+  public function buildPage(?stdClass $profile = NULL, ?string $contact_checksum = NULL) {
     $config = Drupal::config('civicrm_newsletter.settings');
     $page = [];
     $messages = [];

--- a/src/Form/PreferencesForm.php
+++ b/src/Form/PreferencesForm.php
@@ -75,7 +75,7 @@ class PreferencesForm extends FormBase {
   public function buildForm(
     array $form,
     FormStateInterface $form_state,
-    stdClass $profile = NULL,
+    ?stdClass $profile = NULL,
     $contact_checksum = NULL
   ) {
     $config = Drupal::config('civicrm_newsletter.settings');

--- a/src/Form/RequestLinkForm.php
+++ b/src/Form/RequestLinkForm.php
@@ -76,7 +76,7 @@ class RequestLinkForm extends FormBase {
   public function buildForm(
     array $form,
     FormStateInterface $form_state,
-    stdClass $profile = NULL,
+    ?stdClass $profile = NULL,
     $contact_checksum = NULL
   ) {
     // If a checksum is given, submit to the request API action without showing a form.

--- a/src/Form/SubscriptionForm.php
+++ b/src/Form/SubscriptionForm.php
@@ -73,7 +73,7 @@ class SubscriptionForm extends FormBase {
   /**
    * @inheritDoc
    */
-  public function buildForm(array $form, FormStateInterface $form_state, stdClass $profile = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?stdClass $profile = NULL) {
     $config = Drupal::config('civicrm_newsletter.settings');
 
     // Include the Advanced Newsletter Management profile name.
@@ -105,7 +105,7 @@ class SubscriptionForm extends FormBase {
         );
       }
     }
-    
+
     // Add contact fields.
     foreach ($profile->contact_fields as $contact_field_name => $contact_field) {
       if (isset($contact_field['active']) && $contact_field['active']) {


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.

Should be backported to 1.1 as well.