### PR TITLE
Disable caching

### DIFF
--- a/civicrm_newsletter.routing.yml
+++ b/civicrm_newsletter.routing.yml
@@ -5,6 +5,8 @@ civicrm_newsletter.config_form:
     _form: '\Drupal\civicrm_newsletter\Form\ConfigForm'
   requirements:
     _permission: 'administer civicrm newsletter'
+  options:
+    no_cache: TRUE
 
 civicrm_newsletter.subscription_form:
   path: '/civicrm_newsletter/subscribe/{profile}'
@@ -17,6 +19,7 @@ civicrm_newsletter.subscription_form:
     parameters:
       profile:
         type: civicrm_newsletter_profile
+    no_cache: TRUE
 
 civicrm_newsletter.optin:
   path: '/civicrm_newsletter/optin/{profile}/{contact_checksum}'
@@ -62,3 +65,4 @@ civicrm_newsletter.request_link_form:
         type: civicrm_newsletter_profile
       contact_checksum:
         type: string
+    no_cache: TRUE


### PR DESCRIPTION
Backport of #35 to 1.1.x.

The content of the sites depend on configuration in CiviCRM and thus must not be cached.